### PR TITLE
Added missing `break` statement in `document.onkeypress`

### DIFF
--- a/js/player.js
+++ b/js/player.js
@@ -144,6 +144,7 @@ document.onkeypress = function (event) {
         player.automationtoggle = bool;
         player.autoUpgrades = bool;
         player.autoBooster = bool;
+        break;
       case "1":
         if (hasUpg(2, "dark")) L2_ABILITY.resize.use();
         break;


### PR DESCRIPTION
Previously, the missing `break` statement meant that toggling autobuyers also caused ability 1 to fire.