### PR TITLE
Fix the conditions under which achievements 13 and 20 are awarded.

### DIFF
--- a/js/layers/1-booster.js
+++ b/js/layers/1-booster.js
@@ -41,7 +41,6 @@ const BOOST = {
   onReset() {
     if (Object.values(player.buyables)
         .every((i,k)=>k===2||k===3||Decimal.lt(i,10))) getAch(12)
-    if (player.boost.time < 60) getAch(19)
     player.boost.times++
   },
 }

--- a/js/layers/1-booster.js
+++ b/js/layers/1-booster.js
@@ -40,7 +40,7 @@ const BOOST = {
   },
   onReset() {
     if (Object.values(player.buyables)
-        .every((i,k)=>k===3||Decimal.lt(i,10))) getAch(12)
+        .every((i,k)=>k===2||k===3||Decimal.lt(i,10))) getAch(12)
     if (player.boost.time < 60) getAch(19)
     player.boost.times++
   },


### PR DESCRIPTION
Previously these achievements were awarded under conditions that didn't match their descriptions. Achievement 13 "Nerd Boosters" required fewer than 10 of each building, even though the description excluded Producers. Achievement 20 "One and Only One" had the correct condition implemented, but there was also an extraneous line that awarded it when boosting in under 60 seconds

Both of these issues are resolved by this pull request.