### PR TITLE
Fix typo in Darken hotkey code

### DIFF
--- a/js/player.js
+++ b/js/player.js
@@ -157,7 +157,7 @@ document.onkeypress = function (event) {
         buyBuyable(3);
         break;
       case "d":
-        doLayer2();
+        doLayer(2);
         break;
       default:
         break;


### PR DESCRIPTION
`doLayer(2)` instead of `doLayer2()`